### PR TITLE
Update config.toml to add ANISE and hifitime

### DIFF
--- a/scraper/config.toml
+++ b/scraper/config.toml
@@ -112,3 +112,12 @@ categories = ["Space protocols", "Parsers"]
 [[crates]]
 name = "sgp4"
 categories = ["Astrodynamics", "Parsers"]
+
+[[crates]]
+name = "anise"
+categories = ["Astrodynamics"]
+
+[[crates]]
+name = "hifitime"
+categories = ["Astrodynamics", "Units of measure"]
+


### PR DESCRIPTION
ANISE is a full rewrite of SPICE in Rust for precise ephemeris calculations, orbital calculations, azimuth and elevation, etc. Hifitime is arguably one of the most precise time management libraries in the world, crucial for time conversions for space systems, supports time scales out of the box (e.g. GPS, TAI, ET, etc.). Both are used in mission critical systems for several space missions.