### PR TITLE
Fixed typo on front page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
       </p>
       <p class="lead">
         Rust has many compelling features and benefits over other languages used in these industries,
-        including easily interoperable with other languages and tool chains.
+        including being easily interoperable with other languages and tool chains.
         <br>
         {# <a href="#learn-more" class="fw-bold">Learn more...</a> #}
       </p>


### PR DESCRIPTION
Added missing word:
> in these industries, including easily interoperable with other languages and tool chains. 

to

>  in these industries, including **being** easily interoperable with other languages and tool chains. 